### PR TITLE
Replace Page with SiteTree

### DIFF
--- a/src/Analysis/Analysis.php
+++ b/src/Analysis/Analysis.php
@@ -2,6 +2,7 @@
 
 namespace Vulcan\Seo\Analysis;
 
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\View\ArrayData;
@@ -51,9 +52,9 @@ abstract class Analysis
     /**
      * Analysis constructor.
      *
-     * @param \Page $page
+     * @param SiteTree $page
      */
-    public function __construct(\Page $page)
+    public function __construct(SiteTree $page)
     {
         $this->setPage($page);
     }
@@ -126,18 +127,17 @@ abstract class Analysis
     }
 
     /**
-     * @param \Page $page
-     *
+     * @param SiteTree $page
      * @return $this
      */
-    public function setPage(\Page $page)
+    public function setPage(SiteTree $page)
     {
         $this->page = $page;
         return $this;
     }
 
     /**
-     * @return \Page|PageHealthExtension
+     * @return SiteTree|PageHealthExtension
      */
     public function getPage()
     {
@@ -166,7 +166,7 @@ abstract class Analysis
         foreach ($this->domParser->find('header,footer,nav') as $item) {
             $item->outertext = '';
         }
-        
+
         return $this->domParser;
     }
 

--- a/src/Extensions/PageHealthExtension.php
+++ b/src/Extensions/PageHealthExtension.php
@@ -35,11 +35,11 @@ class PageHealthExtension extends DataExtension
     public function updateCMSFields(FieldList $fields)
     {
         parent::updateCMSFields($fields);
-        
+
         if ($this->owner instanceof \SilverStripe\ErrorPage\ErrorPage) {
             return;
         }
-        
+
         $fields->addFieldsToTab('Root.Main', [
             ToggleCompositeField::create(null, 'SEO Health Analysis', [
                 GoogleSearchPreview::create('GoogleSearchPreview', 'Search Preview', $this->getOwner(), $this->getRenderedHtmlDomParser()),

--- a/src/Forms/HealthAnalysisField.php
+++ b/src/Forms/HealthAnalysisField.php
@@ -2,6 +2,7 @@
 
 namespace Vulcan\Seo\Forms;
 
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Forms\LiteralField;
 use SilverStripe\ORM\ArrayList;
@@ -37,7 +38,7 @@ class HealthAnalysisField extends LiteralField
      * @param \SilverStripe\Forms\FormField|string $title
      * @param \Page                                $page
      */
-    public function __construct($name, $title, \Page $page)
+    public function __construct($name, $title, SiteTree $page)
     {
         $this->setPage($page);
         Requirements::javascript('vulcandigital/silverstripe-seo:dist/javascript/main.min.js');
@@ -88,18 +89,17 @@ class HealthAnalysisField extends LiteralField
     }
 
     /**
-     * @param \Page $page
-     *
+     * @param SiteTree $page
      * @return $this
      */
-    public function setPage(\Page $page)
+    public function setPage(SiteTree $page)
     {
         $this->page = $page;
         return $this;
     }
 
     /**
-     * @return \Page|PageHealthExtension
+     * @return SiteTree|PageHealthExtension
      */
     public function getPage()
     {


### PR DESCRIPTION
Because I’m awkward, none of my custom page types extend `\Page`, they all extend `App\Model\Page`. Switching to typehinting `SilverStripe\CMS\Model\SiteTree` allows both approaches 😁 