### PR TITLE
Handle file_get_contents() when it cannot retrieve text

### DIFF
--- a/src/Extensions/PageHealthExtension.php
+++ b/src/Extensions/PageHealthExtension.php
@@ -57,9 +57,13 @@ class PageHealthExtension extends DataExtension
     public function getRenderedHtml()
     {
         if (!$this->renderedHtml) {
-            $this->renderedHtml = file_get_contents($this->getOwner()->AbsoluteLink());
+            $this->renderedHtml = @file_get_contents($this->getOwner()->AbsoluteLink());
         }
-
+        
+        if ($this->renderedHtml === false) {
+            $this->renderedHtml = '<p></p>';
+        }
+        
         return $this->renderedHtml;
     }
 


### PR DESCRIPTION
When a page cannot be viewed (say a database error) you instead get errors about the SEO `file_get_contents` call rather than the proper error message. This handles the case if `file_get_contents` returns nothing.