### PR TITLE
Render html using render() rather than file_get_contents etc

### DIFF
--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -1,3 +1,7 @@
+---
+Name: silverstripe-seo
+---
+
 Page:
   extensions:
     - Vulcan\Seo\Extensions\PageHealthExtension

--- a/src/Extensions/PageHealthExtension.php
+++ b/src/Extensions/PageHealthExtension.php
@@ -2,6 +2,8 @@
 
 namespace Vulcan\Seo\Extensions;
 
+use SilverStripe\CMS\Controllers\ModelAsController;
+use SilverStripe\Control\Controller;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\TextField;
@@ -41,7 +43,7 @@ class PageHealthExtension extends DataExtension
         }
 
         $fields->addFieldsToTab('Root.Main', [
-            ToggleCompositeField::create(null, 'SEO Health Analysis', [
+            ToggleCompositeField::create('SEOHealthAnalysis', 'SEO Health Analysis', [
                 GoogleSearchPreview::create('GoogleSearchPreview', 'Search Preview', $this->getOwner(), $this->getRenderedHtmlDomParser()),
                 TextField::create('FocusKeyword', 'Set focus keyword'),
                 HealthAnalysisField::create('ContentAnalysis', 'Content Analysis', $this->getOwner()),
@@ -57,7 +59,8 @@ class PageHealthExtension extends DataExtension
     public function getRenderedHtml()
     {
         if (!$this->renderedHtml) {
-            $this->renderedHtml = file_get_contents($this->getOwner()->AbsoluteLink().'?stage=Stage');
+            $controllerName = $this->owner->getControllerName();
+            $this->renderedHtml = $controllerName::singleton()->render($this->owner);
         }
         
         if ($this->renderedHtml === false) {

--- a/src/Extensions/PageSeoExtension.php
+++ b/src/Extensions/PageSeoExtension.php
@@ -84,13 +84,13 @@ class PageSeoExtension extends DataExtension
         parent::updateCMSFields($fields);
 
         $fields->addFieldsToTab('Root.Main', [
-            ToggleCompositeField::create(null, 'Facebook SEO', [
+            ToggleCompositeField::create('FacebookSeoComposite', 'Facebook SEO', [
                 DropdownField::create('FacebookPageType', 'Type', FacebookMetaGenerator::getValidTypes()),
                 TextField::create('FacebookPageTitle', 'Title')->setAttribute('placeholder', $this->getOwner()->Title)->setRightTitle('If blank, inherits default page title')->setTargetLength(45, 25, 70),
                 UploadField::create('FacebookPageImage', 'Image')->setRightTitle('Facebook recommends images to be 1200 x 630 pixels. If no image is provided, facebook will choose the first image that appears on the page which usually has bad results')->setFolderName('seo'),
                 TextareaField::create('FacebookPageDescription', 'Description')->setAttribute('placeholder', $this->getOwner()->MetaDescription ?: $this->getOwner()->dbObject('Content')->LimitCharacters(297))->setRightTitle('If blank, inherits meta description if it exists or gets the first 297 characters from content')->setTargetLength(200, 160, 320),
             ]),
-            ToggleCompositeField::create(null, 'Twitter SEO', [
+            ToggleCompositeField::create('TwitterSeoComposite', 'Twitter SEO', [
                 TextField::create('TwitterPageTitle', 'Title')->setAttribute('placeholder', $this->getOwner()->Title)->setRightTitle('If blank, inherits default page title')->setTargetLength(45, 25, 70),
                 UploadField::create('TwitterPageImage', 'Image')->setRightTitle('Must be at least 280x150 pixels')->setFolderName('seo'),
                 TextareaField::create('TwitterPageDescription', 'Description')->setAttribute('placeholder', $this->getOwner()->MetaDescription ?: $this->getOwner()->dbObject('Content')->LimitCharacters(297))->setRightTitle('If blank, inherits meta description if it exists or gets the first 297 characters from content')->setTargetLength(200, 160, 320),


### PR DESCRIPTION
1. Render Html using render() rather than file_get_contents
2. Config Yaml name added for the purpose of After/Before priority. 
3. Grid Field modified: field names added so that fields can be moved.